### PR TITLE
fix gpiochip missing from stream

### DIFF
--- a/server/io.go
+++ b/server/io.go
@@ -54,6 +54,7 @@ func newPin(pinstStat Pins) (*IoPin, error) {
 		Alias:    pinstStat.Alias,
 		Value:    pinstStat.Value,
 		AsOutput: pinstStat.Output,
+		GpioChip: pinstStat.GpioChip,
 	}
 
 	if io.AsOutput {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -58,6 +58,12 @@ func (s *server) GetGPIOList(in *pb.ClientRequest, stream pb.Rio_GetGPIOListServ
 
 	for _, x := range s.exportedPins {
 
+		logrus.Debugf("line: %d", x.Line.Offset())
+		logrus.Debugf("value: %d", x.Value)
+		logrus.Debugf("alias: %s", x.Alias)
+		logrus.Debugf("output: %v", x.AsOutput)
+		logrus.Debugf("gpiochip: %s", x.GpioChip)
+
 		// go from x (type IOpin) to gpioToStream (GPIOselected) ...
 		gpioToStream := pb.GPIOselected{
 			GPIOLineOffset: int32(x.Line.Offset()),
@@ -67,7 +73,7 @@ func (s *server) GetGPIOList(in *pb.ClientRequest, stream pb.Rio_GetGPIOListServ
 			GPIOChip:       x.GpioChip,
 		}
 
-		logrus.Debugf("sending: %v\n", x)
+		logrus.Debugf("sending: %v\n", gpioToStream)
 
 		err := stream.Send(&gpioToStream)
 		if err != nil {


### PR DESCRIPTION
Gpiochip was missing from the stream, and from the IO pin struct as a whole!

This has been fixed.